### PR TITLE
Calificaciones (Estudiante) - En la modal mostrar el nombre de la cuenta - Issue/8049

### DIFF
--- a/Backend/app/controllers/student_exercises_controller.rb
+++ b/Backend/app/controllers/student_exercises_controller.rb
@@ -159,8 +159,7 @@ class StudentExercisesController < ApplicationController
   end
 
   def find_mark_exercise_by_user
-
-    @exercises = Exercise.includes(:task, marks: { student_entries: :student_annotations })
+    @exercises = Exercise.includes(:task, marks: { student_entries: { student_annotations: :account } })
                           .where(user_id: current_user.id)
                           .page(params[:page])
                           .per(params[:per_page] || 5)
@@ -172,7 +171,11 @@ class StudentExercisesController < ApplicationController
           marks: {
             include: {
               student_entries: {
-                include: :student_annotations
+                include: {
+                  student_annotations: {
+                    include: { account: { only: [:name] } }
+                  }
+                }
               }
             }
           }

--- a/Frontend/src/components/student-mark/StudentMark.jsx
+++ b/Frontend/src/components/student-mark/StudentMark.jsx
@@ -95,6 +95,7 @@ const StudentMark = () => {
                                     <tr>
                                       <th>Nº</th>
                                       <th>Nº Cuenta</th>
+                                      <th>Nombre Cuenta</th>
                                       <th>Debe</th>
                                       <th>Haber</th>
                                     </tr>
@@ -105,6 +106,7 @@ const StudentMark = () => {
                                         <tr key={index + annotation.account_number}>
                                           <td>{index + 1}</td>
                                           <td>{annotation.account_number}</td>
+                                          <td>{annotation.account?.name}</td>
                                           <td>{annotation.debit}</td>
                                           <td>{annotation.credit}</td>
                                         </tr>


### PR DESCRIPTION
En la ventana modal que aparece al hacer click en la calificación de una tarea debe aparecer también el nombre de la cuenta (y no sólo el nº de la cuenta).

Se ha añadido el campo "Nombre de Cuenta" en la modal de calificaciones del rol alumno.

En el backend, era necesario incluir la relación account en las student_annotations.

![image](https://github.com/user-attachments/assets/f7a4d200-5334-4944-b5d1-df79f1d4b59b)
