### PR TITLE
Orden de las pestañas auxiliares en los distintos modos - issue/8038

### DIFF
--- a/Frontend/src/components/aux-section-two/AuxSectionTwo.jsx
+++ b/Frontend/src/components/aux-section-two/AuxSectionTwo.jsx
@@ -54,15 +54,15 @@ const AuxSectionTwo = ({ statements, examStarted, onSelectStatement, isTaskActiv
                 );
               })}
             </div>
-            {selectedStatement && (
+            {selectedStatement ? (
               <div className="statement-detail">
-                <h3 className="statement-detail__title">Enunciado {statements.indexOf(selectedStatement) + 1}</h3>
+                <h3 className="statement-detail__title">Enunciado {statements.findIndex(s => s.id === selectedStatement?.id) + 1}</h3>
                 <div className="statement-detail__content">
                   <p><strong>Definición:</strong> {selectedStatement.definition}</p>
                   <p><strong>Explicación:</strong> {selectedStatement.explanation || "Sin explicación."}</p>
                 </div>
               </div>
-            )}
+            ) : <p>Sin enunciado seleccionado</p>}
           </section>
         </div>
       }

--- a/Frontend/src/components/aux-section/AuxSection.jsx
+++ b/Frontend/src/components/aux-section/AuxSection.jsx
@@ -22,7 +22,7 @@ export const AuxSection = ({ statements, examStarted, onSelectStatement, helpAva
     if (helpAvailable && !isExam) {
       setAuxSection("help_example");
     } else {
-      setAuxSection("balance");
+      setAuxSection("statements");
     }
   }, [helpAvailable, isExam]);
 
@@ -32,7 +32,7 @@ export const AuxSection = ({ statements, examStarted, onSelectStatement, helpAva
         return (
           <AuxSectionTwo
             statements={statements}
-            examStarted={isExam ? examStarted : true}
+            examStarted={examStarted}
             onSelectStatement={onSelectStatement}
           />
         );


### PR DESCRIPTION
En modo Practica ya estaba puesto Ayuda por defecto entonces no toque nada de esa parte.

### En el modo Ejercicio y modo examen sale por defecto ahora los enunciados.

antes:
![image](https://github.com/user-attachments/assets/82e70ae3-e0c3-49b3-96c7-a3b2bff5cbb8)
Después:
![image](https://github.com/user-attachments/assets/69d12fed-c97f-4606-a557-c710771c7ea5)

### Antes se podían ver los enunciados sin empezar la tarea:

![image](https://github.com/user-attachments/assets/45963403-a4b2-4acd-a3a5-37b8168264b9)

### Ahora no se muestren si no se empieza la tarea:

![image](https://github.com/user-attachments/assets/26ada47b-4fce-4b7c-87fe-7904be5d70ea)

