### PR TITLE
#Issue/8041 - Explanation field removed from Statement

### DIFF
--- a/Backend/app/controllers/statements_controller.rb
+++ b/Backend/app/controllers/statements_controller.rb
@@ -15,8 +15,8 @@ class StatementsController < ApplicationController
 
       if params[:search].present?
         search_term = "%#{params[:search]}%"
-        statements = statements.where("definition ILIKE ? OR explanation ILIKE ?", search_term, search_term)
-      end
+        statements = statements.where("definition ILIKE ?", search_term)
+      end     
 
       paginated_statements = statements.page(params[:page]).per(params[:per_page] || 10)
 
@@ -263,8 +263,7 @@ class StatementsController < ApplicationController
   def statement_params
     Rails.logger.debug "Params received: #{params[:statement].inspect}"
     params.require(:statement).permit(
-      :definition,
-      :explanation,
+      :definition, 
       :is_public,
       solutions_attributes: [
         :id,

--- a/Backend/app/models/statement.rb
+++ b/Backend/app/models/statement.rb
@@ -7,6 +7,5 @@ class Statement < ApplicationRecord
   accepts_nested_attributes_for :solutions, allow_destroy: true
 
   validates :definition, presence: true
-  validates :explanation, presence: true, allow_blank: true
   validates :is_public, inclusion: { in: [true, false] }
 end

--- a/Backend/app/serializers/statement_serializer.rb
+++ b/Backend/app/serializers/statement_serializer.rb
@@ -1,5 +1,5 @@
 class StatementSerializer < ActiveModel::Serializer
-  attributes :id, :definition, :explanation, :user_id, :is_public
+  attributes :id, :definition, :user_id, :is_public
 
   has_many :solutions, serializer: SolutionSerializer
 end

--- a/Backend/db/migrate/20250218113032_remove_explanation_from_statements.rb
+++ b/Backend/db/migrate/20250218113032_remove_explanation_from_statements.rb
@@ -1,0 +1,5 @@
+class RemoveExplanationFromStatements < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :statements, :explanation, :text
+  end
+end 

--- a/Backend/db/schema.rb
+++ b/Backend/db/schema.rb
@@ -156,7 +156,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_15_125450) do
 
   create_table "statements", force: :cascade do |t|
     t.text "definition"
-    t.text "explanation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/Frontend/src/components/aux-section-two/AuxSectionTwo.jsx
+++ b/Frontend/src/components/aux-section-two/AuxSectionTwo.jsx
@@ -59,7 +59,6 @@ const AuxSectionTwo = ({ statements, examStarted, onSelectStatement, isTaskActiv
                 <h3 className="statement-detail__title">Enunciado {statements.findIndex(s => s.id === selectedStatement?.id) + 1}</h3>
                 <div className="statement-detail__content">
                   <p><strong>Definición:</strong> {selectedStatement.definition}</p>
-                  <p><strong>Explicación:</strong> {selectedStatement.explanation || "Sin explicación."}</p>
                 </div>
               </div>
             ) : <p>Sin enunciado seleccionado</p>}

--- a/Frontend/src/components/statements/StatementForm.jsx
+++ b/Frontend/src/components/statements/StatementForm.jsx
@@ -3,7 +3,6 @@ import statementService from "../../services/statementService";
 
 const StatementForm = ({ onStatementCreated, onAddSolution, solutions, setSolutions, onSaveSolution, statement, onDeleteSolution }) => {
   const [definition, setDefinition] = useState(statement?.definition || "");
-  const [explanation, setExplanation] = useState(statement?.explanation || "");
   const [isPublic, setIsPublic] = useState(statement?.is_public || false);
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
@@ -14,7 +13,6 @@ const StatementForm = ({ onStatementCreated, onAddSolution, solutions, setSoluti
   useEffect(() => {
     if (statement?.id && (JSON.stringify(prevStatementRef.current) !== JSON.stringify(statement))) {
       setDefinition(statement?.definition || "");
-      setExplanation(statement?.explanation || "");
       setIsPublic(statement?.is_public || false);
       setSolutions(statement?.solutions?.map(s => ({ ...s, entries: s.entries || [] })) || []);
     }
@@ -138,7 +136,6 @@ const StatementForm = ({ onStatementCreated, onAddSolution, solutions, setSoluti
 
     const statementData = {
       definition,
-      explanation,
       is_public: isPublic,
       solutions_attributes: (solutions || []).map((solution) => ({
         ...(solution.id && { id: solution.id }),
@@ -173,6 +170,9 @@ const StatementForm = ({ onStatementCreated, onAddSolution, solutions, setSoluti
       setSuccessMessage(statement?.id ? "Enunciado actualizado correctamente." : "Enunciado creado correctamente.");
       clearSuccessMessage();
 
+      setDefinition("");
+      setIsPublic(false);
+      setSolutions([]);
       setFieldErrors({});
     } catch (error) {
       if (error.response) {
@@ -208,16 +208,6 @@ const StatementForm = ({ onStatementCreated, onAddSolution, solutions, setSoluti
             onChange={(e) => setDefinition(e.target.value)}
           />
           {fieldErrors.definition && <div className="error-message">{fieldErrors.definition}</div>}
-        </div>
-        <div className="statement-page__form--content">
-          <label className="statement-page__label--explanation" htmlFor="explanation">Explicación:</label>
-          <textarea
-            id="explanation"
-            className="statement-page__input--explanation"
-            value={explanation}
-            onChange={(e) => setExplanation(e.target.value)}
-          />
-          {fieldErrors.explanation && <div className="error-message">{fieldErrors.explanation}</div>}
         </div>
 
         <div className="statement-page__buttons-container">


### PR DESCRIPTION
- [X] Se ha creado una migración para eliminar de la base de datos la columna "Explanation" de Statement.
- [X] Actualización del modelo, controlador y serializer
- [X] Actualización de los componentes que mostraban dicho campo (Formulario de creación de Statements y en la TaskPage)

![image](https://github.com/user-attachments/assets/06f413e7-58cc-460e-b14c-027813de0b23)

![image](https://github.com/user-attachments/assets/24cb4932-6cd1-4df3-a7f0-505d6c134a2f)


