### PR TITLE
Corrección del título en modo práctica: cambiar "modo tarea" por "modo práctica" - Issue/8025

### DIFF
--- a/Frontend/src/pages/modes/practice-page/PracticePage.jsx
+++ b/Frontend/src/pages/modes/practice-page/PracticePage.jsx
@@ -22,7 +22,7 @@ const PracticePage = () => {
 
   return (
     <div className='modes_page_container practice_color'>
-      <h1 className='head_task'>Modo Tarea</h1>
+      <h1 className='head_task'>Modo Práctica</h1>
 
       <div className="entry__container">
         <EntryHeader


### PR DESCRIPTION
Incidencia #72 - Cuando el estudiante entra en el modo práctica aparece en el título sobre fondo amarillo "modo tarea". Cambiarlo y poner "modo práctica".

- [ ] Se ha modificado en el Modo Práctica el texto del título de "Modo Tarea" a "Modo Práctica".

![image](https://github.com/user-attachments/assets/3f2fa1c0-9831-4c39-8de1-1a61bae014ff)
