### PR TITLE
Lista de grupos - No se muestran los datos a partir de la página 2 - Issue/8059

### DIFF
--- a/Frontend/src/services/ClassGroupService.js
+++ b/Frontend/src/services/ClassGroupService.js
@@ -1,9 +1,9 @@
 import http from "../http-common";
 
-const getAll = async (page = 1, perPage = 10) => {
+const getAll = async (page = 1, perPage = 10, name = "") => {
     try {
         const response = await http.get("/class_groups", {
-            params: { page, per_page: perPage }
+            params: { page, per_page:perPage, course_module: name }
         });
         return response;
     } catch (error) {


### PR DESCRIPTION
-  Se pueden ver los datos a en todas las paginas, antes no se veían los datos que no estuvieran en la pagina 1.

![image](https://github.com/user-attachments/assets/66319d7d-cac5-42f6-a58e-8d1d08431451)

- El buscador puede encontrar los datos que no estén en la primera pagina, antes solo buscaba en la pagina en la que estuviera en ese momento.