### PR TITLE
Issue/8063 - View Solution marked as HelpExample inside TaskPage (Help tab)

### DIFF
--- a/Frontend/src/components/aux-section/AuxSection.jsx
+++ b/Frontend/src/components/aux-section/AuxSection.jsx
@@ -37,7 +37,10 @@ export const AuxSection = ({ statements, examStarted, onSelectStatement, helpAva
           />
         );
       case "help_example":
-        return <HelpSection statementId={selectedStatement?.id} />;
+        if (!selectedStatement) {
+          return <div>Selecciona un enunciado para ver la ayuda</div>;
+        }
+        return <HelpSection statementId={selectedStatement.id} />;
       case "balance":
         return <RealTimeTrialBalance entries={entries} />;
       case "mayor":
@@ -45,7 +48,7 @@ export const AuxSection = ({ statements, examStarted, onSelectStatement, helpAva
       default:
         return null;
     }
-  }, [auxSection, statements, examStarted, onSelectStatement, entries, isExam]);
+  }, [auxSection, statements, examStarted, onSelectStatement, entries, isExam, selectedStatement]);
 
   const changeAuxSection = (section) => {
     setAuxSection(section);

--- a/Frontend/src/components/help-section/HelpSection.jsx
+++ b/Frontend/src/components/help-section/HelpSection.jsx
@@ -18,17 +18,18 @@ const HelpSection = ({statementId}) => {
         return;
       }
 
+      setIsLoading(true);
       try {
-        setIsLoading(true);
         const response = await solutionService.getExampleSolution(statementId);
-        console.log("Solución de ejemplo:", response.data);
         if (response && response.data) {
           setSolution(response.data);
+        } else {
+          setIsError(true);
         }
-        setIsLoading(false);
       } catch (error) {
         console.error("Error al obtener la solución de ejemplo:", error);
         setIsError(true);
+      } finally {
         setIsLoading(false);
       }
     };
@@ -56,9 +57,12 @@ const HelpSection = ({statementId}) => {
     solution.entries.forEach(entry => {
       entry.annotations?.forEach(annotation => {
         if (annotation.account) {
-          accounts.set(annotation.account_number, {
+          accounts.set(annotation.account.account_number, {
             ...annotation.account,
-            account_number: annotation.account_number
+            account_number: annotation.account.account_number,
+            description: annotation.account.description,
+            charge: annotation.account.charge,
+            credit: annotation.account.credit
           });
         }
       });
@@ -155,7 +159,7 @@ const HelpSection = ({statementId}) => {
                           <div className="help_section__entry_form">
                             <div className="help_section__entry_form_inputs__wrapper">
                               <div className="help_section__form_group help_section__account_number_group">
-                                <span className="help_section__account_number">{annotation.account_number}</span>
+                                <span className="help_section__account_number">{annotation.account?.account_number}</span>
                               </div>
                               <div className="help_section__form_group help_section__account_name_group">
                                 <span className="help_section__account_name">{annotation.account?.name || ''}</span>

--- a/Frontend/src/pages/modes/task-page/TaskPage.jsx
+++ b/Frontend/src/pages/modes/task-page/TaskPage.jsx
@@ -95,9 +95,10 @@ const TaskPage = () => {
           });
           setStatementData(newStatementData);
 
-          const targetStatement = response.exercise.marks?.[0]?.statement_id;
-
-          setSelectedStatement(targetStatement);
+          const firstStatement = response.exercise.task.statements?.[0];
+          if (firstStatement) {
+            setSelectedStatement(firstStatement);
+          }
         }
       } catch (error) {
         console.error("Error fetching exercise:", error);
@@ -274,6 +275,7 @@ const TaskPage = () => {
           onSelectStatement={handleSelectStatement}
           examStarted={taskStarted}
           helpAvailable={exercise.task.help_available}
+          selectedStatement={selectedStatement}
           entries={Object.values(statementData).flatMap(data =>
             data.entries?.map(entry => ({
               ...entry,


### PR DESCRIPTION
Nuevamente se muestra la Solution marcada como HelpExample dentro de la pestaña Ayuda de TaskPage. Además de otra información como una breve descripción de la propia solución, y los motivos de Cargo y a Abono de las cuentas involucradas.

Se ha probado de ambas formas: creando un enunciado y solución de cero, y editando un enunciado existente. En los dos casos la solución se marca como HelpExample. Posteriormente se crea una Tarea habilitando la opción de Ayuda, y asignando el enunciado correspondiente. Después como alumno entramos a la tarea y vemos lo siguiente:

![image](https://github.com/user-attachments/assets/67e17ae3-6669-4e80-9c6f-0fffcdbd1f71)

