### PR TITLE
Role switching fixed - issue/8040

### DIFF
--- a/Frontend/src/components/navigation-menu/header/dropdown/DropdownContent.jsx
+++ b/Frontend/src/components/navigation-menu/header/dropdown/DropdownContent.jsx
@@ -6,26 +6,29 @@ import { useAuth } from "../../../../context/AuthContext";
 const DropdownContent = () => {
   const { logOut } = useAuth();
   const [rolMenu, setRolMenu] = useState(false)
-  const { currentRole, isAdmin, setAdminRol } = useContext(navContext);
+  const { currentRole, isAdmin, setAdminRol, isTeacher } = useContext(navContext);
 
   const selectorStatus = () => {
     setRolMenu(!rolMenu)
   }
 
+  const canChangeRol = () => {
+    return (isAdmin || isTeacher)
+  }
+
   return (
     <>
       <ul className="userMenu">
-        {isAdmin && currentRole === "student" ? <li className="userMenu_item" tabIndex={0} onClick={setAdminRol}><a> <i className="fi fi-rr-user-coach"></i>Vista admin</a></li> : null}
-        {(currentRole === "teacher" || currentRole === "admin") && (<li className="userMenu_item" tabIndex={0} onClick={selectorStatus}><a> <i className="fi fi-rr-user"></i> Cambio de rol</a></li>)}
-        {rolMenu && currentRole !== "student" ? <RolMenu /> : null}
+        {canChangeRol() && (<li className="userMenu_item" tabIndex={0} onClick={selectorStatus}><a> <i className="fi fi-rr-user"></i> Cambio de rol</a></li>)}
+        {(canChangeRol() && rolMenu) ? <RolMenu /> : null}
         <li className="userMenu_item" tabIndex={0}><a> <i className="fi fi-rr-info"></i> Ayuda y privacidad</a></li>
-        <li 
-          className="userMenu_item" 
-          tabIndex={0} 
-          onClick={logOut} 
+        <li
+          className="userMenu_item"
+          tabIndex={0}
+          onClick={logOut}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
-            logOut();
+              logOut();
             }
           }}
         ><a> <i className="fi fi-rr-power"></i> Cerrar Sesión</a></li>

--- a/Frontend/src/components/navigation-menu/header/dropdown/RolMenu.jsx
+++ b/Frontend/src/components/navigation-menu/header/dropdown/RolMenu.jsx
@@ -3,12 +3,12 @@ import { navContext } from '../../../../context/nav-menu/navMenuContext';
 
 const RolMenu = () => {
 
-  const { setAdminRol, setTeacherRol, setStudentRol } = useContext(navContext);
+  const { setAdminRol, setTeacherRol, setStudentRol, isAdmin } = useContext(navContext);
 
 
   return (
     <ul>
-      <li className="userMenu_item" tabIndex={0} onClick={setAdminRol}><a> <i className="fi fi-rr-user"></i>Admin</a></li>
+      {isAdmin && <li className="userMenu_item" tabIndex={0} onClick={setAdminRol}><a> <i className="fi fi-rr-user"></i>Admin</a></li>}
       <li className="userMenu_item" tabIndex={0} onClick={setTeacherRol}><a> <i className="fi fi-rr-user"></i>Profesor</a></li>
       <li className="userMenu_item" tabIndex={0} onClick={setStudentRol}><a> <i className="fi fi-rr-user"></i>Estudiante</a></li>
     </ul>


### PR DESCRIPTION
Ahora se puede volver a ver la lista de roles una cambias a estudiante, antes no se podía desde profesor , también se cambio para que siempre se vea igual y no ponga vista de admin.

<table>
  <thead>
    <tr>
      <th align="center"><strong>Antes:</strong></th>
      <th align="center"><strong>Después:</strong></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/a4132981-b934-48f8-af53-eede1384e0f4" alt="Antes" width="300"/></td>
      <td><img src="https://github.com/user-attachments/assets/63f3250e-56aa-4c8f-bae4-0b408b17ebfa" alt="Después" width="300"/></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/673a12db-4031-4b1a-a282-1c69d89e9fe3" alt="Antes" width="300"/></td>
      <td><img src="https://github.com/user-attachments/assets/92646d2b-5659-4cc5-9830-37c59612d1e5" alt="Después" width="300"/></td>
    </tr>
  </tbody>
</table>
<hr/>
