### PR TITLE
Changed the shortcut name  - issue/8064

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -173,7 +173,7 @@
     flex: 1;
     font-size: 16px;
     color: var(--Color-Neutral-White);
-    text-align: left;
+    text-align: center;
     white-space: nowrap;
   }
 

--- a/Frontend/src/components/shortcuts/shortcut/Shortcut.css
+++ b/Frontend/src/components/shortcuts/shortcut/Shortcut.css
@@ -38,5 +38,5 @@
   font-weight: 600;
   line-height: 140%;
   text-transform: capitalize;
-
+  text-align: center;
 }

--- a/Frontend/src/services/ShortcutRoutes.js
+++ b/Frontend/src/services/ShortcutRoutes.js
@@ -31,7 +31,7 @@ scRoutes.push({
 scRoutes.push({
   to: "/home/escuelas",
   icon: "fi fi-rr-school",
-  name: "Colegios",
+  name: "Centro Educativo",
   rol: ["admin"],
 })
 


### PR DESCRIPTION
Cambiado el nombre de Escuelas a Centros educativos y alienado al centro en el texto.

<table>
  <thead>
    <tr>
      <th align="center"><strong>Antes:</strong></th>
      <th align="center"><strong>Después:</strong></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/973ff5fe-7112-43b2-800d-8a59f53c4746" alt="Antes" width="300"/></td>
      <td><img src="https://github.com/user-attachments/assets/5bbd9285-9f06-4de2-bf5e-9bc1365481e7" alt="Después" width="300"/></td>
    </tr>
 
  </tbody>
</table>