### PR TITLE
Publish or hide all marks

### DIFF
--- a/Frontend/src/components/task/MarkList.css
+++ b/Frontend/src/components/task/MarkList.css
@@ -59,7 +59,6 @@
   gap: var(--gap-l);
   justify-content: left;
   align-items: center;
-
 }
 
 .mark_list__header {
@@ -115,4 +114,27 @@
     padding: var(--gap-s);
     color: var(--Color-Principal);
   }
+}
+
+.mark_list__header-buttons {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.visibility-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.visibility-buttons .btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.visibility-buttons .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: var(--Color-grey-100);
 }


### PR DESCRIPTION
Se han agregado dos botones para habilitar o no la visualización de todas las notas de una tarea.

![image](https://github.com/user-attachments/assets/701dd031-08c8-4303-a4b3-96596e8743da)

Si todas las notas del listado tienen el mismo estado, la acción contraria se muestra deshabilitada. En caso de que hayan diferentes estados, ambas opciones están habilitadas.

![image](https://github.com/user-attachments/assets/f1f45392-eec4-4c94-8eda-632cd1685bef)

La PR de la Issue/8007 queda descartada.