### PR TITLE
Remove auth headers in AccountingPlan service

### DIFF
--- a/Frontend/src/components/solution/SolutionList.jsx
+++ b/Frontend/src/components/solution/SolutionList.jsx
@@ -41,7 +41,7 @@ const SolutionList = ({ solutions, onEditSolution, onDeleteSolution, solutionToD
         await solutionService.markAsExample(solutionId, {
           creditMoves: "0",
           debitMoves: "0",
-          account_id: 1,
+          account_id: 42,
           solution: solutionData
         });
       }

--- a/Frontend/src/services/AccountingPlanService.js
+++ b/Frontend/src/services/AccountingPlanService.js
@@ -1,16 +1,9 @@
 import http from "../http-common";
 
-// ✅ Ajout automatique du token dans toutes les requêtes protégées
-const getAuthHeaders = () => {
-    const token = localStorage.getItem("jwt_token");
-    return token ? { Authorization: `Bearer ${token}` } : {};
-};
-
 const getAll = async (page = 1, perPage = 10, name = "") => {
     try {
-        const response = await http.get("/accounting_plans", {// "Backend/config/routes.rb"
-            params: {page, per_page: perPage, name},
-            headers: getAuthHeaders()
+        const response = await http.get("/accounting_plans", {
+            params: {page, per_page: perPage, name}
         });
         return response.data;
     } catch (error) {
@@ -21,9 +14,7 @@ const getAll = async (page = 1, perPage = 10, name = "") => {
 
 const get = async (id) => {
     try {
-        const response = await http.get(`/accounting_plans/${id}`, {
-            headers: getAuthHeaders()
-        });
+        const response = await http.get(`/accounting_plans/${id}`);
         return response;
     } catch (error) {
         console.error("Error en la petición get:", error);
@@ -31,12 +22,9 @@ const get = async (id) => {
     }
 };
 
-  
 const create = async (data) => {
     try {
-        const response = await http.post("/accounting_plans", data, {
-            headers: getAuthHeaders()
-        });
+        const response = await http.post("/accounting_plans", data);
         return response;
     } catch (error) {
         console.error("Error en la creación:", error);
@@ -46,9 +34,7 @@ const create = async (data) => {
 
 const update = async (id, data) => {
     try {
-        const response = await http.put(`/accounting_plans/${id}`, data, {
-            headers: getAuthHeaders()
-        });
+        const response = await http.put(`/accounting_plans/${id}`, data);
         return response;
     } catch (error) {
         console.error("Error en la actualización:", error);
@@ -58,9 +44,7 @@ const update = async (id, data) => {
 
 const remove = async (id) => {
     try {
-        const response = await http.delete(`/accounting_plans/${id}`, {
-            headers: getAuthHeaders()
-        })
+        const response = await http.delete(`/accounting_plans/${id}`);
         return response;
     } catch (error) {
         console.error("Error en la eliminación:", error);
@@ -70,9 +54,7 @@ const remove = async (id) => {
 
 const removeAll = async () => {
     try {
-        const response = await http.delete("/accounting_plans", {
-            headers: getAuthHeaders()
-        });
+        const response = await http.delete("/accounting_plans");
         return response;
     } catch (error) {
         console.error("Error en la eliminación de todos:", error);
@@ -83,8 +65,7 @@ const removeAll = async () => {
 const findByName = async (name) => {
     try {
         const response = await http.get(`/accounting_plans`, {
-            params: {name}, 
-            headers: getAuthHeaders()
+            params: {name}
         });
         return response.data;
     } catch (error) {
@@ -93,22 +74,17 @@ const findByName = async (name) => {
     }
 };
 
-
 const getAccountsByPGC = (id) => {
-    return http.get(`/accounting_plans/${id}/accounts_by_PGC`,{
-        headers: getAuthHeaders()
-    });
-  };
+    return http.get(`/accounting_plans/${id}/accounts_by_PGC`);
+};
 
-  
 const exportToCSV = async (id) => {
     try {
         const response = await http.get(`/accounting_plans/${id}/export_csv`, {
             headers: {
-                ...getAuthHeaders(),
                 "Accept": "text/csv" // csv response
             },
-            responseType: "blob", // as file
+            responseType: "blob" // as file
         });
 
         // Verify csv
@@ -139,9 +115,8 @@ const importCSV = async (file) => {
 
         const response = await http.post("/accounting_plans/import_csv", formData, {
             headers: { 
-                "Content-Type": "multipart/form-data",
-                ...getAuthHeaders() 
-            },
+                "Content-Type": "multipart/form-data"
+            }
         });
 
         if (response.data.success) {
@@ -158,7 +133,6 @@ const exportXLSXByPGC = async (id) => {
     try {
         const response = await http.get(`/accounting_plans/${id}/export_xlsx_by_pgc`, {
             headers: {
-                ...getAuthHeaders(),
                 "Accept": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             },
             responseType: "blob"
@@ -188,8 +162,7 @@ const importXLSX = async (formData) => {
     try {
         const response = await http.post("/accounting_plans/import_xlsx", formData, {
             headers: {
-                "Content-Type": "multipart/form-data",
-                Authorization: `Bearer ${localStorage.getItem("jwt_token")}`,
+                "Content-Type": "multipart/form-data"
             }
         });
 


### PR DESCRIPTION
Se ha eliminado la función getAuthHeaders() de los métodos del servicio. En su lugar usamos el interceptor configurado en http-common al igual que en el resto de servicios.