### PR TITLE
#Issue/8028 - Show PGC Acronym instead PGC id (Accounts list)

### DIFF
--- a/Backend/app/controllers/accounts_controller.rb
+++ b/Backend/app/controllers/accounts_controller.rb
@@ -26,7 +26,7 @@ class AccountsController < ApplicationController
     paginated_accounts = accounts.page(params[:page]).per(params[:per_page] || 10)
 
     render json: {
-      accounts: paginated_accounts,
+      accounts: paginated_accounts.as_json(include: { accounting_plan: { only: [:id, :acronym] } }),
       meta: {
         current_page: paginated_accounts.current_page,
         total_pages: paginated_accounts.total_pages,

--- a/Frontend/src/components/account/ListAccount.jsx
+++ b/Frontend/src/components/account/ListAccount.jsx
@@ -125,7 +125,7 @@ const AccountsList = ({ newAcc }) => {
                   { field: 'account_number', sortable: true },
                   { field: 'name', sortable: true },
                   { field: 'description', sortable: true },
-                  { field: 'accounting_plan_id', sortable: true },
+                  { field: 'accounting_plan', sortable: true, render: (account) => account.accounting_plan?.acronym || '-' },
                   { field: 'charge',},
                   { field: 'credit'}
                 ]}


### PR DESCRIPTION
Ahora en el listado de Cuentas se muestra el acrónimo del PGC al que pertenece. Anteriormente aparecía el id, y el usuario puede no saber con qué plan contable está relacionado ese número.

![image](https://github.com/user-attachments/assets/86c46edb-db71-445a-aa5b-9ac6f210b792)
