### PR TITLE
Search by account number in Account page list

### DIFF
--- a/Frontend/src/components/account/ListAccount.jsx
+++ b/Frontend/src/components/account/ListAccount.jsx
@@ -25,12 +25,12 @@ const AccountsList = ({ newAcc }) => {
 
   useEffect(() => {
     retrieveAccounts(currentPage, searchAccount);
-  }, [newAcc, currentPage, searchAccount]);
+  }, [newAcc, currentPage]);
 
-  const retrieveAccounts = async (page, name) => {
+  const retrieveAccounts = async (page, search) => {
     setIsLoading(true);
     try {
-      const data = await AccountService.getAll(page, 10, name);
+      const data = await AccountService.getAll(page, 10, search);
       if (data) {
         setAccounts(data.accounts);
         setTotalPages(data.meta.total_pages);
@@ -61,21 +61,9 @@ const AccountsList = ({ newAcc }) => {
   }
 
   const handleSearchChange = (value) => {
-    const searchTerm = value;
-    setSearchAccount(searchTerm);
+    setSearchAccount(value);
     setCurrentPage(1);
-
-    if (!searchTerm) {
-      retrieveAccounts();
-      return;
-    }
-
-    setAccounts((prevAccounts) =>
-      prevAccounts.filter((acc) => {
-        acc.name.toLowerCase().includes(searchTerm);
-        setCurrentPage(1);
-      })
-    );
+    retrieveAccounts(1, value);
   };
 
   const openEditModal = (id) => {

--- a/Frontend/src/services/AccountService.js
+++ b/Frontend/src/services/AccountService.js
@@ -1,9 +1,9 @@
 import http from "../http-common";
 
-const getAll = async (page = 1, perPage = 10, name = "", accountNumber = "") => {
+const getAll = async (page = 1, perPage = 10, search = "") => {
   try {
     const response = await http.get("/accounts", {
-      params: { page, per_page: perPage, name, account_number: accountNumber }
+      params: { page, per_page: perPage, search }
     });
     return response.data;
   } catch (error) {


### PR DESCRIPTION
Se ha agregado la posibilidad de buscar por el número de cuenta en el listado de Account page. También se han eliminado conversiones (toLowerCase) en el código del componente que no son necesarias, porque en el backend ya se maneja toda la lógica para el filtrado. 

Se mantiene la búsqueda por nombre de cuenta.

![image](https://github.com/user-attachments/assets/e183f665-c247-49e8-a6c8-242988beeaed)

![image](https://github.com/user-attachments/assets/5664209c-450c-40dc-a9b9-6189dad4e41c)
