### PR TITLE
fix/ Show Credit and Charge fields in Accounts modal (PGC page)

### DIFF
--- a/Frontend/src/components/accounting-plan/ListAccountingPlan.jsx
+++ b/Frontend/src/components/accounting-plan/ListAccountingPlan.jsx
@@ -210,6 +210,8 @@ const AccountingPlansList = ({ newPGC }) => {
                   <th>Nº Cuenta</th>
                   <th>Nombre</th>
                   <th>Descripción</th>
+                  <th>Cargo</th>
+                  <th>Crédito</th>
                 </tr>
               </thead>
               <tbody>
@@ -218,6 +220,8 @@ const AccountingPlansList = ({ newPGC }) => {
                     <td>{account.account_number}</td>
                     <td>{account.name}</td>
                     <td>{account.description}</td>
+                    <td>{account.charge}</td>
+                    <td>{account.credit}</td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
Ahora cuando se abre la modal de Cuentas pertenecientes a un PGC (icono del ojo), se muestran también los campos de cargo y abono de las cuentas.